### PR TITLE
fix name and text overflow on mobile devices

### DIFF
--- a/src/Message.svelte
+++ b/src/Message.svelte
@@ -48,8 +48,8 @@
 </script>
 
 <div class="message">
-  <img src="{getContext('LUOXU_URL')}/avatar/{msg.from_id}.jpg" height="64" width="64" alt="{msg.from_name} 的头像"/>
-  <div>
+  <img class="avatar" src="{getContext('LUOXU_URL')}/avatar/{msg.from_id}.jpg" height="64" width="64" alt="{msg.from_name} 的头像"/>
+  <div class="content">
     <div class="name">{msg.from_name || ' '}</div>
     <div class="text">{@html msg.html}</div>
     <div class="time">{groupinfo[msg.group_id][1]} <a href={msgurl}><time datetime={iso_date} title={title}>{relative_dt}</time></a></div>
@@ -66,12 +66,17 @@
     border-radius: 5px;
     display: flex;
   }
-  img {
+  .avatar {
     padding-right: 0.5em;
+  }
+  .content {
+    overflow: hidden;
   }
   .name {
     white-space: nowrap;
     color: #1e90ff;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
   .text {
     white-space: pre-wrap;


### PR DESCRIPTION
Use `overflow: hidden` on text and it's container, and `ext-overflow: ellipsis` on text itself.

|Before|After|
|:----:|:---:|
|![image](https://user-images.githubusercontent.com/13914967/148485837-859491bd-d97e-4976-b716-f706f889ff1b.png)|![image](https://user-images.githubusercontent.com/13914967/148485666-aaee2e5a-07f7-4f93-8ab0-49fbdf496d15.png)|
